### PR TITLE
fixed bug with FileUtilImpl test to check for read access to /var/lib/waagent./ovf-env.xml

### DIFF
--- a/plugin-azure-agent/src/main/kotlin/jetbrains/buildServer/clouds/azure/FileUtilsImpl.kt
+++ b/plugin-azure-agent/src/main/kotlin/jetbrains/buildServer/clouds/azure/FileUtilsImpl.kt
@@ -31,7 +31,7 @@ class FileUtilsImpl : FileUtils {
 
     override fun readFile(file: File): String {
         val parentDir = file.parentFile
-        if (SystemInfo.isUnix && parentDir.exists() && parentDir.isDirectory && !parentDir.canExecute()) {
+        if (SystemInfo.isUnix && parentDir.exists() && parentDir.isDirectory && !parentDir.canExecute() && !file.canRead()) {
             LOG.info("Reading file content $file with sudo")
             return readFileWithSudo(file)
         }


### PR DESCRIPTION
So after ~18 hours or so of trying to figure out why my Windows Azure build agents don't auto-authorize on Linux using the v0.8.8 version of this plugin, I went down the rabbit hole of trying the solutions posted in this thread: https://github.com/JetBrains/teamcity-azure-agent/issues/86#issuecomment-365042798 but without any success.

I documented my attempted fixes and work-arounds here: https://stackoverflow.com/questions/54057576/ansible-azure-give-user-permission-to-read-files-owned-by-root-that-dont-exi

Turns out though, that a `strace` of the `agent.sh` start process revealed that the Azure plugin never actually tries to read the file with `sudo` permissions on this system, because all of these checks pass:

https://github.com/JetBrains/teamcity-azure-agent/blob/9d267ce798f8218fc153d5d73bc954ede52e1250/plugin-azure-agent/src/main/kotlin/jetbrains/buildServer/clouds/azure/FileUtilsImpl.kt#L34-L39

`FileUtil.readText` gets called when really the `readFileWithSudo` method should be called. So I added an additional `!file.canRead` check at the end to make sure that if we can't read the file via `FileUtil`, we'll definitely try the `sudo` approach.

Might also be a good idea to wrap the `FileUtil.readText` call in a `try`...`catch` block and fall back to attempting to do with `sudo` anyway.